### PR TITLE
Add into_rust into the master list

### DIFF
--- a/master-list.md
+++ b/master-list.md
@@ -238,6 +238,7 @@ focus.
 - [rustlings](https://github.com/carols10cents/rustlings)
 - [exercism.io](http://www.exercism.io/languages/rust)
 - [Rust Cookbook](https://brson.github.io/rust-cookbook)
+- [into_rust()](http://intorust.com)
 
 ## Additional Long-Form Reading
 


### PR DESCRIPTION
A while back, Niko Matsakis made these screencasts, I think these are very easy to follow.

Btw, while doing this, I randomly stumbled on this(which also seems to be linked from the official docs page): https://github.com/ctjhoa/rust-learning

Maybe the effort could be merged somehow?